### PR TITLE
README: quick start instruction

### DIFF
--- a/README.md
+++ b/README.md
@@ -2,12 +2,35 @@
 
 Icarus, a reference implementation for a lightweight wallet, which will enable developers to create their own wallets for Cardano. Icarus runs in a browser as a Google Chrome extension and offers an easy-to-use alternative to Daedalus. This wallet does not need to download and validate a copy of the Cardano blockchain, instead, it uses a copy of the blockchain on a server, so it offers advantages in terms of speed of use. Icarus is secure – private keys are encrypted on the user's browser and not shared with servers. Releasing the source code will mean the community can develop wallets and integrate with Cardano as required and Cardano moves further towards decentralisation.
 
-## Project layout
+## Getting started
+
+Have a look at the project's architecture to get a better understanding of the project:
+<https://github.com/input-output-hk/project-icarus/wiki/Architecture>
+
+### Project layout
+
+Here are the different pieces of the architecture:
 
 * [backend/](https://github.com/input-output-hk/project-icarus-backend-service) - the source of the backend webapp
 * [importer/](https://github.com/input-output-hk/project-icarus-importer) - the chain importer
 * [chrome-extension/](https://github.com/input-output-hk/project-icarus-chrome) - the source of the chrome extension
 
+### Quickstart
+
+Here are the instructions to build and run everything locally. It requires Nix, Docker and docker-compose to be installed on the machine.
+
+To build and start the backend run these commands:
+
+```sh
+docker load -i "$(nix-build importer/ -A dockerImages.testnetBlockchainImporter --argstr gitrev "undefined" --no-out-link)"
+docker-compose up -d
+```
+
+It will start the database, importer and webapp. Once it's booted, run `curl --insecure https://localhost:8080/api/healthcheck` to verify that the stack is working properly.
+
+Now that the backend is running, let's build and run the Chrome Extension.
+
+TODO: how to do that?
 
 ## License
 

--- a/docker-compose.yaml
+++ b/docker-compose.yaml
@@ -16,15 +16,15 @@ services:
       - POSTGRES_PASSWORD=devpassword
       - POSTGRES_USER=icarus-dev
       - POSTGRES_DB=icarus-blockchain-importer
-    networks:
-      - development
-
+    volumes:
+      - postgres-data:/var/lib/postgresql/data
 
   # This setup task initializes the database on first startup.
   # On later startups the init fails and it directly exists.
   postgres-setup:
     container_name: icarus-postgres-setup
     restart: "no"
+    # image: icarus/postgres-setup
     build:
       context: .
       # based on upstream docker as well, with schema in scope
@@ -42,8 +42,6 @@ services:
       - "--file=./schema.sql"
     environment:
       - PGPASSWORD=devpassword
-    networks:
-      - development
 
 
   # Fills the database with blocks;
@@ -51,7 +49,6 @@ services:
   blockchain-importer:
     container_name: icarus-blockchain-importer
     restart: on-failure
-    # TODO: push to docker hub
     # image: icarus/blockchain-importer-testnet:latest
     image: cardano-container-testnet:latest
     command:
@@ -78,26 +75,31 @@ services:
     # it to UID/GID 999:999 first (the user of this container).
     # volumes:
     #   - ./path/to/mywallet:/wallet
-    networks:
-      - development
+    volumes:
+      - importer-data:/wallet
 
 
   # The backend process the Chrome plugin talks to.
   backend:
     container_name: icarus-backend
-    # TODO: push to docker hub
-    image: icarus/backend:latest
+    # image: icarus/backend:latest
+    ports:
+      - "8080:8080"
     build:
       context: ./backend
       dockerfile: ./docker/Dockerfile
     restart: on-failure
 
     environment:
-      # this loads the config from `backend/config/develop.js`
+      # load the config from `backend/config/develop.js`
       - NODE_ENV=develop
-      # … and overrides some fields
+      # add some more configuration
       - >-
         NODE_CONFIG={
+          "server": {
+            "importerSendTxEndpoint": "http://blockchain-importer:8200",
+            "port": 8080
+          },
           "db": {
             "user": "icarus-dev",
             "host": "postgres",
@@ -106,11 +108,8 @@ services:
             "port": 5432
           }
         }
-    networks:
-      - development
 
 
-# set one network that every image is in
-networks:
-  development:
-    driver: bridge
+volumes:
+  postgres-data:
+  importer-data:


### PR DESCRIPTION
Use docker volumes to keep the data across restarts. Fixes out of sync
issues between RocksDB and Postgres.

Tell the webapp about the importer address.